### PR TITLE
Added remaining CRUD endpoints for the '/jobs' route with proper auth

### DIFF
--- a/affiliates-rest-controller.php
+++ b/affiliates-rest-controller.php
@@ -73,6 +73,7 @@ class Affiliates_REST_Controller extends WP_REST_Controller {
         return rest_ensure_response( $data );
     }
 
+    // Callback function to create a new job
     public function create_job( $request ) {
         // Required fields
         $required_fields = array( 'title', 'job_description', 'contact' );
@@ -120,11 +121,96 @@ class Affiliates_REST_Controller extends WP_REST_Controller {
         return rest_ensure_response( array( 'id' => $job_id, 'title' => $request['title'] ) );
     }
 
+    // Callback function to get a specific job by ID
+    public function get_job( $request ) {
+        $job_id = $request['id'];
+
+        $job = get_post( $job_id );
+
+        if ( empty( $job ) || 'job' !== $job->post_type ) {
+            return new WP_Error( 'job_not_found', __( 'Job not found', 'affiliates-portal' ), array( 'status' => 404 ) );
+        }
+
+        $data = array(
+            'id'      => $job->ID,
+            'title'   => $job->post_title,
+            'author'  => get_the_author_meta( 'display_name', $job->post_author ),
+            'job_description' => $job->post_content,
+            'contact' => get_post_meta( $job->ID, 'contact', true ),
+        );
+
+        return rest_ensure_response( $data );
+    }
+
+    // Callback function to edit a specific job by ID
+    public function edit_job( $request ) {
+        $job_id = $request['id'];
+
+        $job = get_post( $job_id );
+
+        if ( empty( $job ) || 'job' !== $job->post_type ) {
+            return new WP_Error( 'job_not_found', __( 'Job not found', 'affiliates-portal' ), array( 'status' => 404 ) );
+        }
+
+        $job_data = array();
+
+        if ( ! empty( $request['title'] ) ) {
+            $job_data['post_title'] = sanitize_text_field( $request['title'] );
+        }
+
+        if ( ! empty( $request['job_description'] ) ) {
+            $job_data['post_content'] = sanitize_textarea_field( $request['job_description'] );
+        }
+
+        if ( ! empty( $request['contact'] ) ) {
+            update_post_meta( $job_id, 'contact', sanitize_text_field( $request['contact'] ) );
+        }
+
+        $updated = wp_update_post( array_merge( array( 'ID' => $job_id ), $job_data ) );
+
+        if ( is_wp_error( $updated ) ) {
+            return new WP_Error( 'cant-update', __( 'Cannot update job', 'affiliates-portal' ), array( 'status' => 500 ) );
+        }
+
+        return rest_ensure_response( array( 'id' => $job_id, 'title' => $request['title'] ) );
+    }
+
+    // Callback function to delete a specific job by ID
+    public function delete_job( $request ) {
+        $job_id = $request['id'];
+
+        $job = get_post( $job_id );
+
+        if ( empty( $job ) || 'job' !== $job->post_type ) {
+            return new WP_Error( 'job_not_found', __( 'Job not found', 'affiliates-portal' ), array( 'status' => 404 ) );
+        }
+
+        $deleted = wp_delete_post( $job_id );
+
+        if ( ! $deleted ) {
+            return new WP_Error( 'cant-delete', __( 'Cannot delete job', 'affiliates-portal' ), array( 'status' => 500 ) );
+        }
+
+        return rest_ensure_response( array( 'deleted' => true ) );
+    }
+
     public function get_jobs_permissions_check( $request ) {
         return true;
     }
 
     public function create_job_permissions_check( $request ) {
         return current_user_can( 'edit_posts' );
+    }
+
+    public function get_job_permissions_check( $request ) {
+        return true;
+    }
+
+    public function edit_job_permissions_check( $request ) {
+        return current_user_can( 'edit_posts' );
+    }
+
+    public function delete_job_permissions_check( $request ) {
+        return current_user_can( 'delete_posts' );
     }
 }


### PR DESCRIPTION
## Changes
---
Added the following endpoints with proper auth:
- Get Job by ID
- Edit Job by ID
- Delete Job by ID